### PR TITLE
Check for text in title

### DIFF
--- a/tests/acceptance/WelcomeCept.php
+++ b/tests/acceptance/WelcomeCept.php
@@ -4,5 +4,5 @@ codecept_debug($capabilities);
 $I = new AcceptanceTester($scenario);
 $I->wantTo('ensure that frontpage works');
 $I->amOnPage('/');
-$I->see('Google')
+$I->seeInTitle('Google');
 ?>


### PR DESCRIPTION
In some cases we are failing to find the 'Google' text on the
page. This appears to be because the text 'Google' is actually not
present on the page, rather than an issue with the TestObject platform.

To improve the robustness of the test, we check for the text 'Google' in
the title instead.